### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/CommuniVatePro/a4e3bd96-3f8e-4965-8aa9-2bf9917d30d4/494441f7-505e-4fcc-ba53-0b80448335ac/_apis/work/boardbadge/ecbcb8f9-8287-47bc-82ab-e85f012b00d1)](https://dev.azure.com/CommuniVatePro/a4e3bd96-3f8e-4965-8aa9-2bf9917d30d4/_boards/board/t/494441f7-505e-4fcc-ba53-0b80448335ac/Microsoft.RequirementCategory)
 # CommuniVate-Pro
 Public speaking and Presentation training service


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/CommuniVatePro/a4e3bd96-3f8e-4965-8aa9-2bf9917d30d4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.